### PR TITLE
Integrate OCR phase into IntrospectHandler map mode

### DIFF
--- a/dylib/bridge/PepperOCR.swift
+++ b/dylib/bridge/PepperOCR.swift
@@ -1,0 +1,64 @@
+import Vision
+import CoreGraphics
+import os
+
+/// Runs Vision OCR on a CGImage and returns recognized text observations.
+enum PepperOCR {
+
+    /// A single recognized text region from OCR.
+    struct TextObservation {
+        let text: String
+        let confidence: Float
+        /// Bounding rect in screen coordinates (origin top-left).
+        let boundingRect: CGRect
+        /// Center point in screen coordinates.
+        var center: CGPoint { CGPoint(x: boundingRect.midX, y: boundingRect.midY) }
+    }
+
+    private static let logger = PepperLogger.logger(category: "ocr")
+
+    /// Runs VNRecognizeTextRequest synchronously on the given image.
+    /// Vision returns normalized coordinates (origin bottom-left, 0..1).
+    /// Results are converted to screen coordinates using `imageSize`.
+    /// Returns observations sorted top-to-bottom by center Y.
+    static func recognizeText(in image: CGImage, imageSize: CGSize) -> [TextObservation] {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        do {
+            try handler.perform([request])
+        } catch {
+            logger.error("OCR failed: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+
+        guard let results = request.results else { return [] }
+
+        var observations: [TextObservation] = []
+        for result in results {
+            guard let candidate = result.topCandidates(1).first else { continue }
+            // Skip very low confidence results
+            guard candidate.confidence > 0.3 else { continue }
+
+            // Convert Vision normalized rect (bottom-left origin) to screen coords (top-left origin)
+            let box = result.boundingBox
+            let rect = CGRect(
+                x: box.origin.x * imageSize.width,
+                y: (1.0 - box.origin.y - box.height) * imageSize.height,
+                width: box.width * imageSize.width,
+                height: box.height * imageSize.height
+            )
+
+            observations.append(TextObservation(
+                text: candidate.string,
+                confidence: candidate.confidence,
+                boundingRect: rect
+            ))
+        }
+
+        observations.sort { $0.center.y < $1.center.y }
+        return observations
+    }
+}

--- a/dylib/bridge/PepperOCRDedup.swift
+++ b/dylib/bridge/PepperOCRDedup.swift
@@ -1,0 +1,50 @@
+import CoreGraphics
+
+/// Deduplicates OCR text observations against existing accessibility-sourced elements.
+/// Removes OCR results that match accessibility text within proximity tolerance.
+enum PepperOCRDedup {
+
+    /// Filters OCR observations, removing any that duplicate existing accessibility text.
+    /// A duplicate is defined as: same text (case-insensitive) within `proximity` points,
+    /// OR center within `proximity` points of any covered center.
+    ///
+    /// - Parameters:
+    ///   - observations: OCR text observations to filter.
+    ///   - existingText: Accessibility-sourced text elements (label + center).
+    ///   - coveredCenters: Spatial hash of centers already claimed by accessibility elements.
+    ///   - proximity: Maximum distance in points to consider a match. Default 15pt.
+    /// - Returns: Observations that have no accessibility-sourced equivalent.
+    static func deduplicate(
+        _ observations: [PepperOCR.TextObservation],
+        existingText: [(label: String, center: CGPoint)],
+        coveredCenters: SpatialHash,
+        proximity: CGFloat = 15
+    ) -> [PepperOCR.TextObservation] {
+        observations.filter { obs in
+            // Skip if center is near an already-covered position
+            if coveredCenters.contains(x: obs.center.x, y: obs.center.y) {
+                return false
+            }
+
+            // Skip if text matches an existing accessibility element nearby
+            let obsLower = obs.text.lowercased()
+            for existing in existingText {
+                guard let label = Optional(existing.label), !label.isEmpty else { continue }
+                let labelLower = label.lowercased()
+                // Check text similarity: exact match or one contains the other
+                let textMatch = obsLower == labelLower
+                    || obsLower.contains(labelLower)
+                    || labelLower.contains(obsLower)
+                if textMatch {
+                    let dx = abs(obs.center.x - existing.center.x)
+                    let dy = abs(obs.center.y - existing.center.y)
+                    if dx < proximity && dy < proximity {
+                        return false
+                    }
+                }
+            }
+
+            return true
+        }
+    }
+}

--- a/dylib/commands/handlers/IntrospectHandler.swift
+++ b/dylib/commands/handlers/IntrospectHandler.swift
@@ -746,6 +746,36 @@ struct IntrospectHandler: PepperHandler {
                 mergedInteractive, nearestTo: point, direction: direction, count: count)
         }
 
+        // Phase 5½: OCR — capture window, run Vision text recognition, deduplicate
+        // against accessibility-sourced text, and collect survivors.
+        // Only runs when the caller passes ocr: true.
+        let ocrRequested = command.params?["ocr"]?.boolValue ?? false
+        var ocrSurvivors: [PepperOCR.TextObservation] = []
+        if ocrRequested {
+            if let cgImage = PepperWindowCapture.captureWindow() {
+                let imageSize = UIScreen.main.bounds.size
+                let observations = PepperOCR.recognizeText(in: cgImage, imageSize: imageSize)
+
+                // Build lookup of existing accessibility text for dedup
+                let existingText: [(label: String, center: CGPoint)] =
+                    (mergedInteractive.compactMap { elem -> (String, CGPoint)? in
+                        guard let label = elem.label else { return nil }
+                        return (label, elem.center)
+                    }) + (allDiscoveredText.compactMap { elem -> (String, CGPoint)? in
+                        guard let label = elem.label else { return nil }
+                        return (label, elem.center)
+                    })
+
+                ocrSurvivors = PepperOCRDedup.deduplicate(
+                    observations,
+                    existingText: existingText,
+                    coveredCenters: coveredCenters
+                )
+
+                logger.info("OCR: \(observations.count) observations, \(ocrSurvivors.count) survivors after dedup")
+            }
+        }
+
         // Phase 6: Sort interactive elements by Y, assign ordinal indices for
         // duplicate labels, then group into rows by Y-band
         mergedInteractive.sort { $0.center.y < $1.center.y }
@@ -829,6 +859,21 @@ struct IntrospectHandler: PepperHandler {
             "rows": AnyCodable(rows),
             "non_interactive": AnyCodable(nonInteractiveSerialized),
         ]
+        if !ocrSurvivors.isEmpty {
+            data["ocr_text"] = AnyCodable(ocrSurvivors.map { obs -> AnyCodable in
+                AnyCodable([
+                    "text": AnyCodable(obs.text),
+                    "center": AnyCodable([AnyCodable(Int(obs.center.x)), AnyCodable(Int(obs.center.y))]),
+                    "confidence": AnyCodable(Double(round(obs.confidence * 100) / 100)),
+                    "frame": AnyCodable([
+                        AnyCodable(Int(obs.boundingRect.origin.x)),
+                        AnyCodable(Int(obs.boundingRect.origin.y)),
+                        AnyCodable(Int(obs.boundingRect.width)),
+                        AnyCodable(Int(obs.boundingRect.height)),
+                    ]),
+                ] as [String: AnyCodable])
+            })
+        }
         if let title = navTitle, !title.isEmpty {
             data["nav_title"] = AnyCodable(title)
         }


### PR DESCRIPTION
## Summary

- Adds three new helpers: `PepperWindowCapture` (CGImage capture), `PepperOCR` (VNRecognizeTextRequest wrapper), `PepperOCRDedup` (filters OCR results against accessibility text)
- Wires them into `IntrospectHandler.handleMap()` as Phase 5½, gated by `ocr: true` parameter
- OCR survivors appear in a separate `ocr_text` array with text, center, confidence, and bounding rect — existing response fields are unchanged

## What changed

| File | Change |
|------|--------|
| `dylib/bridge/PepperWindowCapture.swift` | New — renders key window to CGImage via `drawHierarchy` |
| `dylib/bridge/PepperOCR.swift` | New — runs `VNRecognizeTextRequest`, converts Vision normalized coords to screen coords |
| `dylib/bridge/PepperOCRDedup.swift` | New — deduplicates OCR observations against accessibility-sourced text by proximity + text matching |
| `dylib/commands/handlers/IntrospectHandler.swift` | Adds OCR phase after spatial filtering, serializes survivors into `ocr_text` response field |

## Test plan

- [ ] Deploy to simulator, run `look` without `ocr` param — verify response is unchanged
- [ ] Run `look` with `ocr: true` — verify `ocr_text` array appears with text, center, confidence, frame
- [ ] Verify OCR results don't duplicate accessibility-sourced text
- [ ] Check performance impact is acceptable (OCR adds ~100-200ms)

Fixes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- pepper-mirror-pr-565 -->
