### PR TITLE
Improve MCP tool descriptions for tap, scroll, swipe, gesture

### DIFF
--- a/dylib/commands/handlers/GestureHandler.swift
+++ b/dylib/commands/handlers/GestureHandler.swift
@@ -59,10 +59,12 @@ struct GestureHandler: PepperHandler {
         )
 
         if success {
-            return .ok(
+            let zoomDir = endDist > startDist ? "zoom in" : "zoom out"
+            return .action(
                 id: command.id,
-                data: [
-                    "gesture": AnyCodable("pinch"),
+                action: "pinch",
+                target: zoomDir,
+                extra: [
                     "center": AnyCodable([
                         "x": AnyCodable(center.x),
                         "y": AnyCodable(center.y),
@@ -90,15 +92,15 @@ struct GestureHandler: PepperHandler {
         )
 
         if success {
-            return .ok(
+            return .action(
                 id: command.id,
-                data: [
-                    "gesture": AnyCodable("rotate"),
+                action: "rotate",
+                target: "\(angle)°",
+                extra: [
                     "center": AnyCodable([
                         "x": AnyCodable(center.x),
                         "y": AnyCodable(center.y),
                     ]),
-                    "angle": AnyCodable(angle),
                     "radius": AnyCodable(radius),
                 ])
         }

--- a/dylib/commands/handlers/ScrollHandler.swift
+++ b/dylib/commands/handlers/ScrollHandler.swift
@@ -275,10 +275,11 @@ struct ScrollHandler: PepperHandler {
         )
 
         if success {
-            return .ok(
+            return .action(
                 id: command.id,
-                data: [
-                    "direction": AnyCodable(direction),
+                action: "scroll",
+                target: direction,
+                extra: [
                     "amount": AnyCodable(Double(amount)),
                     "duration": AnyCodable(duration),
                     "gesture": AnyCodable([

--- a/dylib/commands/handlers/SwipeHandler.swift
+++ b/dylib/commands/handlers/SwipeHandler.swift
@@ -99,9 +99,12 @@ struct SwipeHandler: PepperHandler {
         )
 
         if success {
-            return .ok(
+            let dir = command.params?["direction"]?.stringValue ?? "custom"
+            return .action(
                 id: command.id,
-                data: [
+                action: "swipe",
+                target: dir,
+                extra: [
                     "from": AnyCodable(["x": AnyCodable(Double(from.x)), "y": AnyCodable(Double(from.y))]),
                     "to": AnyCodable(["x": AnyCodable(Double(to.x)), "y": AnyCodable(Double(to.y))]),
                     "duration": AnyCodable(duration),

--- a/dylib/commands/handlers/TapHandler.swift
+++ b/dylib/commands/handlers/TapHandler.swift
@@ -143,11 +143,12 @@ struct TapHandler: PepperHandler {
             if let errorMsg = errorMsg, errorMsg.hasPrefix("__tab_selected__:") {
                 let idx = String(errorMsg.dropFirst("__tab_selected__:".count))
                 logger.warning("Tab \(idx) selected programmatically — no tab bar button found for touch synthesis")
-                return .ok(
+                return .action(
                     id: command.id,
-                    data: [
+                    action: "tap",
+                    target: "tab[\(idx)]",
+                    extra: [
                         "strategy": AnyCodable("tab_index"),
-                        "description": AnyCodable("tab[\(idx)]"),
                         "type": AnyCodable("tab"),
                         "programmatic": AnyCodable(true),
                         "warning": AnyCodable(
@@ -197,11 +198,12 @@ struct TapHandler: PepperHandler {
             }
             if knownTabs.contains(normalized) {
                 if tabBar.pepper_selectTab(named: text) {
-                    return .ok(
+                    return .action(
                         id: command.id,
-                        data: [
+                        action: "tap",
+                        target: "tab:\(text)",
+                        extra: [
                             "strategy": AnyCodable("tab_index"),
-                            "description": AnyCodable("tab:\(text)"),
                             "type": AnyCodable("programmatic_tab"),
                         ])
                 }
@@ -347,9 +349,8 @@ struct TapHandler: PepperHandler {
 
         if success {
             logger.info("Tapped \(description) via HID at (\(point.x), \(point.y))")
-            var data: [String: AnyCodable] = [
+            var extra: [String: AnyCodable] = [
                 "strategy": AnyCodable(strategy),
-                "description": AnyCodable(description),
                 "type": AnyCodable("hid_touch"),
                 "tap_point": AnyCodable([
                     "x": AnyCodable(Double(point.x)),
@@ -358,9 +359,9 @@ struct TapHandler: PepperHandler {
             ]
             if debug {
                 let windows = UIWindow.pepper_allVisibleWindows
-                data["tap_diagnostics"] = AnyCodable(buildTapDiagnostics(at: point, in: windows))
+                extra["tap_diagnostics"] = AnyCodable(buildTapDiagnostics(at: point, in: windows))
             }
-            return .ok(id: command.id, data: data)
+            return .action(id: command.id, action: "tap", target: description, extra: extra)
         } else {
             return .error(id: command.id, message: "HID tap synthesis failed at (\(point.x), \(point.y))")
         }

--- a/tools/mcp_tools_nav.py
+++ b/tools/mcp_tools_nav.py
@@ -156,13 +156,13 @@ def register_nav_tools(mcp, send_command, resolve_and_send, act_and_look):
     @mcp.tool()
     async def tap(
         simulator: str | None = Field(default=None, description="Simulator UDID"),
-        text: str | None = Field(default=None, description="Tap element by visible text/label"),
-        icon: str | None = Field(default=None, description="Tap element by icon name (e.g. 'gift-fill-icon')"),
-        heuristic: str | None = Field(default=None, description="Tap element by heuristic (e.g. 'menu_button')"),
-        point: str | None = Field(default=None, description="Tap at coordinates 'x,y' (e.g. '200,400')"),
-        double: bool = Field(default=False, description="Double-tap (two rapid taps for zoom, like, etc.)"),
-        duration: float | None = Field(default=None, description="Hold duration in seconds. Use >0.5 for long press."),
-        debug: bool = Field(default=False, description="Include tap diagnostics: hit-test result, gesture recognizers, responder chain, and overlapping views. Use when a tap doesn't produce the expected result."),
+        text: str | None = Field(default=None, description="Visible text or label on the element (e.g. 'Save', 'Cancel', 'Settings')"),
+        icon: str | None = Field(default=None, description="SF Symbol or asset name shown on the element (e.g. 'gift-fill-icon', 'chevron.right')"),
+        heuristic: str | None = Field(default=None, description="Semantic role when text/icon aren't available (e.g. 'menu_button', 'close_button', 'back_button')"),
+        point: str | None = Field(default=None, description="Raw screen coordinates as 'x,y' — last resort when no text/icon/heuristic matches (e.g. '200,400')"),
+        double: bool = Field(default=False, description="Double-tap — two rapid taps for zoom, like, or select-word gestures"),
+        duration: float | None = Field(default=None, description="Hold duration in seconds (e.g. 1.0 for long press, 0.5 for peek)"),
+        debug: bool = Field(default=False, description="Include tap diagnostics when a tap doesn't work: hit-test result, gesture recognizers, responder chain, overlapping views"),
     ) -> list:
         """Use this when you need to tap a button, link, cell, or any interactive element.
         Specify exactly one of: text, icon, heuristic, or point.
@@ -197,8 +197,8 @@ def register_nav_tools(mcp, send_command, resolve_and_send, act_and_look):
     @mcp.tool()
     async def scroll(
         simulator: str | None = Field(default=None, description="Simulator UDID"),
-        direction: str = Field(description="Scroll direction: up, down, left, right"),
-        amount: int | None = Field(default=None, description="Scroll amount in points"),
+        direction: str = Field(description="Scroll direction: 'up', 'down', 'left', or 'right' (e.g. 'down' to reveal content below)"),
+        amount: int | None = Field(default=None, description="Distance in points (default ~300). Use larger values like 600 for fast scrolling, smaller like 100 for precise positioning"),
     ) -> list:
         """Use this when you need to reveal content above or below the visible area.
         Performs a slow drag (not a flick). Use swipe for fast flick gestures like dismissing or paging.
@@ -286,7 +286,7 @@ def register_nav_tools(mcp, send_command, resolve_and_send, act_and_look):
     @mcp.tool()
     async def swipe(
         simulator: str | None = Field(default=None, description="Simulator UDID"),
-        direction: str = Field(description="Swipe direction: up, down, left, right"),
+        direction: str = Field(description="Swipe direction: 'up', 'down', 'left', or 'right' (e.g. 'left' to go to next page, 'down' to dismiss a sheet)"),
     ) -> list:
         """Use this when you need a fast flick gesture — paging between screens, dismissing cards, or pull-to-refresh.
         Unlike scroll (slow drag to reveal content), swipe is a quick flick that triggers gesture recognizers.

--- a/tools/mcp_tools_system.py
+++ b/tools/mcp_tools_system.py
@@ -158,12 +158,12 @@ def register_system_tools(mcp, resolve_and_send, act_and_look):
     @mcp.tool()
     async def gesture(
         simulator: str | None = Field(default=None, description="Simulator UDID"),
-        type: str = Field(description="Gesture type: pinch or rotate"),
-        start_distance: int | None = Field(default=None, description="Starting pinch distance in points (for pinch)"),
-        end_distance: int | None = Field(default=None, description="Ending pinch distance in points (for pinch)"),
-        angle: float | None = Field(default=None, description="Rotation angle in degrees (for rotate)"),
-        center_x: float | None = Field(default=None, description="Center X coordinate (defaults to screen center)"),
-        center_y: float | None = Field(default=None, description="Center Y coordinate (defaults to screen center)"),
+        type: str = Field(description="Gesture type: 'pinch' (zoom in/out) or 'rotate' (turn content)"),
+        start_distance: int | None = Field(default=None, description="Pinch start distance in points (e.g. 200). Larger than end_distance = zoom out"),
+        end_distance: int | None = Field(default=None, description="Pinch end distance in points (e.g. 50). Larger than start_distance = zoom in"),
+        angle: float | None = Field(default=None, description="Rotation angle in degrees (e.g. 90 for quarter turn, -45 for counter-clockwise)"),
+        center_x: float | None = Field(default=None, description="Center X coordinate for the gesture (e.g. 200). Defaults to screen center"),
+        center_y: float | None = Field(default=None, description="Center Y coordinate for the gesture (e.g. 400). Defaults to screen center"),
     ) -> str:
         """Perform multi-touch gestures — pinch to zoom or two-finger rotate. Shows screen state after.
 

--- a/tools/pepper-mcp
+++ b/tools/pepper-mcp
@@ -451,7 +451,10 @@ async def act_and_look(simulator: Optional[str], cmd: str, params: Optional[dict
 
     # Format: action result on top, then screen state, then telemetry
     action_data = action_resp.get("data", {})
-    action_summary = action_data.get("description", action_data.get("strategy", cmd))
+    # .action() factory uses "action" + "target"; legacy .ok() uses "description" or "strategy"
+    action_verb = action_data.get("action", cmd)
+    action_target = action_data.get("target", action_data.get("description", action_data.get("strategy", "")))
+    action_summary = f"{action_verb} '{action_target}'" if action_target else action_verb
 
     result = f"Action: {action_summary}\n--- Screen after {cmd} ---\n{screen_summary}"
     if telemetry:


### PR DESCRIPTION
## Summary
- **Tool descriptions** for `tap`, `scroll`, `swipe`, and `gesture` now lead with *when* to use the tool, not just what it does. Parameter descriptions include concrete examples (e.g. `'Save'`, `'200,400'`, `90` degrees).
- **Swift response factories**: all four handlers (`TapHandler`, `ScrollHandler`, `SwipeHandler`, `GestureHandler`) converted from raw `.ok(id:data:)` to `.action(id:action:target:extra:)`, giving structured action/target metadata.
- **Summary line**: `act_and_look` now formats the new fields into a clear summary like `"tap 'Save'"`, `"scroll 'down'"`, `"pinch 'zoom in'"` instead of echoing raw strategy strings.

## Files changed
- `tools/mcp_tools_nav.py` — tap, scroll, swipe docstrings + parameter descriptions
- `tools/mcp_tools_system.py` — gesture docstring + parameter descriptions
- `dylib/commands/handlers/TapHandler.swift` — `.action()` factory (3 sites)
- `dylib/commands/handlers/ScrollHandler.swift` — `.action()` factory (1 site)
- `dylib/commands/handlers/SwipeHandler.swift` — `.action()` factory (1 site)
- `dylib/commands/handlers/GestureHandler.swift` — `.action()` factory (2 sites)
- `tools/pepper-mcp` — `act_and_look` summary formatting for new action/target fields

## Verified
- `make build` passes
- Pre-commit hooks pass (Swift build, SwiftLint, Python syntax, Ruff lint)
- Backwards-compatible: `act_and_look` falls back to `description`/`strategy` keys for any handlers not yet converted

Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- pepper-mirror-pr-553 -->
